### PR TITLE
fix: [gaps-214] - Default content expiry configuration add form content_type validation error

### DIFF
--- a/djangocms_content_expiry/forms.py
+++ b/djangocms_content_expiry/forms.py
@@ -31,12 +31,12 @@ class DefaultContentExpiryConfigurationForm(forms.ModelForm):
         field_key_ctype = 'content_type'
 
         # If adding
-        if 'initial' in kwargs:
+        if not getattr(self.instance, 'pk', None):
             # Only get items that haven't been set yet
             self.fields[field_key_ctype].queryset = self.fields[field_key_ctype].queryset.filter(
                 defaultcontentexpiryconfiguration__isnull=True
             )
-        # Otherwise, viewing / editing
+        # Otherwise, changing (viewing / editing)
         else:
             content_type_field = DefaultContentExpiryConfiguration._meta.get_field(field_key_ctype).remote_field
             self.fields[field_key_ctype].widget = ForeignKeyReadOnlyWidget(content_type_field, site)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -759,7 +759,7 @@ class DefaultContentExpiryConfigurationAdminViewsFormsTestCase(CMSTestCase):
         The Content Type list should only show content types that have not yet been created
         and are registered as versioning compatible.
         """
-        form = admin.site._registry[DefaultContentExpiryConfiguration].form(initial=None)
+        form = admin.site._registry[DefaultContentExpiryConfiguration].form()
         field_content_type = form.fields['content_type']
         versioning_config = apps.get_app_config("djangocms_versioning")
 
@@ -778,7 +778,7 @@ class DefaultContentExpiryConfigurationAdminViewsFormsTestCase(CMSTestCase):
             content_type=poll_content_expiry.version.content_type
         )
 
-        form = admin.site._registry[DefaultContentExpiryConfiguration].form(initial=None)
+        form = admin.site._registry[DefaultContentExpiryConfiguration].form()
         field_content_type = form.fields['content_type']
         versioning_config = apps.get_app_config("djangocms_versioning")
 
@@ -794,6 +794,24 @@ class DefaultContentExpiryConfigurationAdminViewsFormsTestCase(CMSTestCase):
             content_type_list,
         )
 
+    def test_add_form_content_type_submission_not_set(self):
+        """
+        The Content Type list should still show the content type list if
+        the user submitted the form and the content type option was not selected
+        """
+        poll_content_expiry = PollContentExpiryFactory()
+        default_expiry_configuration = DefaultContentExpiryConfigurationFactory(
+            content_type=poll_content_expiry.version.content_type
+        )
+        preload_form_data = {
+            "id": default_expiry_configuration.pk,
+            "duration": default_expiry_configuration.duration,
+        }
+        form = admin.site._registry[DefaultContentExpiryConfiguration].form(preload_form_data)
+        field_content_type = form.fields['content_type']
+
+        self.assertNotEqual(field_content_type.widget.__class__, ForeignKeyReadOnlyWidget)
+
     def test_change_form_content_type_items(self):
         """
         The Content Type control should be read only and not allow the user to change it
@@ -802,12 +820,7 @@ class DefaultContentExpiryConfigurationAdminViewsFormsTestCase(CMSTestCase):
         default_expiry_configuration = DefaultContentExpiryConfigurationFactory(
             content_type=poll_content_expiry.version.content_type
         )
-        preload_form_data = {
-            "id": default_expiry_configuration.pk,
-            "content_type": default_expiry_configuration.content_type.pk,
-            "duration": default_expiry_configuration.duration,
-        }
-        form = admin.site._registry[DefaultContentExpiryConfiguration].form(preload_form_data)
+        form = admin.site._registry[DefaultContentExpiryConfiguration].form(instance=default_expiry_configuration)
         field_content_type = form.fields['content_type']
 
         self.assertEqual(field_content_type.widget.__class__, ForeignKeyReadOnlyWidget)


### PR DESCRIPTION
Fixed and added an additional test to enforce this in the future.

Installed this into my local project using this branch and the fix works
<img width="1792" alt="Screenshot 2021-10-02 at 13 58 31" src="https://user-images.githubusercontent.com/12543977/135717353-671d9ca2-2008-411d-b6f2-904fde1cc480.png">
:
