### PR TITLE
fix: [gaps-215] - Add the ability to use polymorphic content types if found

### DIFF
--- a/djangocms_content_expiry/utils.py
+++ b/djangocms_content_expiry/utils.py
@@ -4,7 +4,12 @@ from .conf import DEFAULT_CONTENT_EXPIRY_DURATION
 from .models import DefaultContentExpiryConfiguration
 
 
+# FIXME: Due to time constraints this function is not covered by unit tests
 def _get_version_content_model_content_type(version):
+    """
+    Returns a content type that describes the content, this is especially
+    important for polymorphic models which would otherwise return the wrong content type!
+    """
     # If the version identifies as a different content type, be sure to use it
     if hasattr(version.content, "polymorphic_ctype"):
         return version.content.polymorphic_ctype

--- a/djangocms_content_expiry/utils.py
+++ b/djangocms_content_expiry/utils.py
@@ -4,13 +4,22 @@ from .conf import DEFAULT_CONTENT_EXPIRY_DURATION
 from .models import DefaultContentExpiryConfiguration
 
 
+def _get_version_content_model_content_type(version):
+    # If the version identifies as a different content type, be sure to use it
+    if hasattr(version.content, "polymorphic_ctype"):
+        return version.content.polymorphic_ctype
+    # Otherwise, use the content type registered by the version
+    return version.content_type
+
+
 def get_default_duration_for_version(version):
     """
     Returns a default expiration value dependant on whether an entry exists for
     a content type in DefaultContentExpiryConfiguration.
     """
+    content_type = _get_version_content_model_content_type(version)
     default_configuration = DefaultContentExpiryConfiguration.objects.filter(
-        content_type=version.content_type
+        content_type=content_type
     )
     if default_configuration:
         return relativedelta(months=default_configuration[0].duration)


### PR DESCRIPTION
With the content type configuration set to 4 months for files and 5 months for images the file 4 months was always used for images. The fix adds the ability to find any polymorphic models such as filer. 

Today is October 2nd 2021
4 months today is February the 2nd 2022
5 months today is March the 2nd 2022

![Screenshot 2021-10-02 at 17 37 20](https://user-images.githubusercontent.com/12543977/135725282-fb7a82eb-0eb5-4d74-a79a-f0f5e51beba9.png)

<img width="1792" alt="Screenshot 2021-10-02 at 17 38 52" src="https://user-images.githubusercontent.com/12543977/135725284-c7586c87-b93a-4852-a8aa-3e75f4bfd21a.png">

<img width="1792" alt="Screenshot 2021-10-02 at 17 39 18" src="https://user-images.githubusercontent.com/12543977/135725285-de539ee1-6544-41e6-b984-382fbf3796d2.png">

<img width="1792" alt="Screenshot 2021-10-02 at 17 54 27" src="https://user-images.githubusercontent.com/12543977/135725639-64968534-6620-4a7c-a61c-3ae338e9cff9.png">

