### PR TITLE
fix: [gaps-228] - Added external sharable links to the CSV url column

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ unreleased
 * fix: Provide content links in the Content Expiry changelist and csv file export
 * fix: Content Expiry changelist filter dates should be for the future not the past
 * fix: CSV export Dates are not formatting correctly in Excel
+* fix: CSV export external urls used for for the url column
 
 0.0.1 (2021-10-04)
 ==================

--- a/djangocms_content_expiry/admin.py
+++ b/djangocms_content_expiry/admin.py
@@ -221,7 +221,9 @@ class ContentExpiryAdmin(admin.ModelAdmin):
             content_type = ContentType.objects.get_for_model(content_expiry.version.content)
             expiry_date = self._format_export_datetime(content_expiry.expires)
             version_state = content_expiry.version.get_state_display()
-            content_url = self._get_preview_url(content_expiry)
+            # Get an external / sharable link
+            preview_url = self._get_preview_url(content_expiry)
+            external_url = request.build_absolute_uri(preview_url)
             # Write a row to the file
             writer.writerow([
                 content_expiry.version.content,
@@ -229,7 +231,7 @@ class ContentExpiryAdmin(admin.ModelAdmin):
                 expiry_date,
                 version_state,
                 content_expiry.version.created_by,
-                content_url,
+                external_url,
             ])
 
         return response

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -204,6 +204,7 @@ class ContentExpiryCsvExportFileTestCase(CMSTestCase):
         datetime expiry date object.
         """
         content_expiry = PollContentExpiryFactory(expires=self.date, version__state=DRAFT)
+        preview_url = content_expiry.version.content.get_preview_url()
 
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(self.export_admin_endpoint)
@@ -234,9 +235,13 @@ class ContentExpiryCsvExportFileTestCase(CMSTestCase):
             content_row_1[self.headings_map["version_author"]],
             content_expiry.version.created_by.username
         )
+        self.assertNotEqual(
+            content_row_1[self.headings_map["url"]],
+            preview_url
+        )
         self.assertEqual(
             content_row_1[self.headings_map["url"]],
-            content_expiry.version.content.get_preview_url()
+            response.wsgi_request.build_absolute_uri(preview_url)
         )
 
     def test_export_button_is_visible(self):


### PR DESCRIPTION
The CSV exported file contained relative links which is not something usable by content authors. 