### PR TITLE
Release 0.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 unreleased
 ==========
+
+0.0.2 (2021-11-01)
+==========
 * fix: Provide content links in the Content Expiry changelist and csv file export
 * fix: Content Expiry changelist filter dates should be for the future not the past
 * fix: CSV export Dates are not formatting correctly in Excel

--- a/djangocms_content_expiry/__init__.py
+++ b/djangocms_content_expiry/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 default_app_config = "djangocms_content_expiry.apps.DjangocmsContentExpiryConfig"


### PR DESCRIPTION
* fix: Provide content links in the Content Expiry changelist and csv file export
* fix: Content Expiry changelist filter dates should be for the future not the past
* fix: CSV export Dates are not formatting correctly in Excel
* fix: CSV export external urls used for for the url column