### PR TITLE
feat: Removed expiry date from version table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 unreleased
 ==========
+* feat: Expiry field removed from version table and replaced with compliance number. Added additional content settings action to version table
 
 1.3.1 (2022-06-22)
 ==================

--- a/djangocms_content_expiry/constants.py
+++ b/djangocms_content_expiry/constants.py
@@ -2,5 +2,6 @@ from django.utils.translation import ugettext_lazy as _
 
 
 CONTENT_EXPIRY_EXPIRE_FIELD_LABEL = _("expiry date")
+CONTENT_EXPIRY_COMPLIANCE_FIELD_LABEL = _("compliance number")
 
 CONTENT_EXPIRY_CHANGELIST_PAGECONTENT_EXCLUSION_CACHE_KEY = "djangocms_content_expiry_changelist_pagecontent_exclusion"

--- a/djangocms_content_expiry/monkeypatch/admin.py
+++ b/djangocms_content_expiry/monkeypatch/admin.py
@@ -43,6 +43,9 @@ def get_state_actions(func):
     return inner
 
 
+admin.VersionAdmin.get_state_actions = get_state_actions(admin.VersionAdmin.get_state_actions)
+
+
 def compliance_number(self, obj):
     version = ContentExpiry.objects.filter(version=obj.pk)
     if version:

--- a/djangocms_content_expiry/monkeypatch/admin.py
+++ b/djangocms_content_expiry/monkeypatch/admin.py
@@ -1,34 +1,67 @@
 from django.conf.urls import url
 from django.shortcuts import redirect
+from django.template.loader import render_to_string
 from django.urls import reverse
 
 from djangocms_moderation import admin as moderation_admin
 from djangocms_moderation.models import ModerationCollection, ModerationRequest
 from djangocms_versioning import admin
 
-from djangocms_content_expiry.constants import CONTENT_EXPIRY_EXPIRE_FIELD_LABEL
+from djangocms_content_expiry.constants import CONTENT_EXPIRY_COMPLIANCE_FIELD_LABEL
 from djangocms_content_expiry.models import ContentExpiry
 
 
-def expires(self, obj):
+def _get_expiry_link(self, obj, request):
+    """
+    Generate an content expiry link for the Versioning Admin
+    """
+    expiry_url = reverse(
+        "admin:{app}_{model}_change".format(
+            app=ContentExpiry._meta.app_label, model=ContentExpiry._meta.model_name
+        ),
+        args=(obj.contentexpiry.pk,),
+    )
+    return render_to_string(
+        'djangocms_content_expiry/calendar_icon.html',
+        {
+            "url": f"{expiry_url}?_popup=1",
+        }
+    )
+
+
+admin.VersionAdmin._get_expiry_link = _get_expiry_link
+
+
+def get_state_actions(func):
+    """
+    Add custom Version Lock actions to Versioning state actions
+    """
+    def inner(self, *args, **kwargs):
+        state_list = func(self, *args, **kwargs)
+        state_list.append(self._get_expiry_link)
+        return state_list
+    return inner
+
+
+def compliance_number(self, obj):
     version = ContentExpiry.objects.filter(version=obj.pk)
     if version:
-        return version[0].expires
+        return version[0].compliance_number
     return ""
 
 
-expires.short_description = CONTENT_EXPIRY_EXPIRE_FIELD_LABEL
-admin.VersionAdmin.expire = expires
+compliance_number.short_description = CONTENT_EXPIRY_COMPLIANCE_FIELD_LABEL
+admin.VersionAdmin.compliance_number = compliance_number
 
 
 def get_list_display(func):
     """
-    Register the expires field with the Versioning Admin
+    Register the compliance number field with the Versioning Admin
     """
     def inner(self, request):
         list_display = func(self, request)
         created_by_index = list_display.index('created_by')
-        return list_display[:created_by_index] + ('expire',) + list_display[created_by_index:]
+        return list_display[:created_by_index] + ('compliance_number',) + list_display[created_by_index:]
 
     return inner
 

--- a/djangocms_content_expiry/monkeypatch/admin.py
+++ b/djangocms_content_expiry/monkeypatch/admin.py
@@ -13,7 +13,7 @@ from djangocms_content_expiry.models import ContentExpiry
 
 def _get_expiry_link(self, obj, request):
     """
-    Generate an content expiry link for the Versioning Admin
+    Generate a content expiry link for the Versioning Admin
     """
     expiry_url = reverse(
         "admin:{app}_{model}_change".format(
@@ -22,7 +22,7 @@ def _get_expiry_link(self, obj, request):
         args=(obj.contentexpiry.pk,),
     )
     return render_to_string(
-        'djangocms_content_expiry/calendar_icon.html',
+        'djangocms_content_expiry/admin/icons/additional_content_settings_icon.html',
         {
             "url": f"{expiry_url}?_popup=1",
         }
@@ -34,7 +34,7 @@ admin.VersionAdmin._get_expiry_link = _get_expiry_link
 
 def get_state_actions(func):
     """
-    Add custom Version Lock actions to Versioning state actions
+    Add additional content settings action to Versioning state actions
     """
     def inner(self, *args, **kwargs):
         state_list = func(self, *args, **kwargs)

--- a/djangocms_content_expiry/templates/djangocms_content_expiry/admin/icons/additional_content_settings_icon.html
+++ b/djangocms_content_expiry/templates/djangocms_content_expiry/admin/icons/additional_content_settings_icon.html
@@ -1,0 +1,5 @@
+{% load static i18n %}
+
+<a class="btn cms-versioning-action-btn related-widget-wrapper-link" href="{{ url }}" title="{% trans 'Additional content settings' %}">
+    <img src="{% static 'djangocms_content_expiry/svg/file.svg' %}">
+</a>

--- a/djangocms_content_expiry/templates/djangocms_content_expiry/calendar_icon.html
+++ b/djangocms_content_expiry/templates/djangocms_content_expiry/calendar_icon.html
@@ -1,2 +1,2 @@
 {% load static i18n %}
-<a class="btn cms-moderation-action-btn js-moderation-action related-widget-wrapper-link" id="change_content_expiry_id_{{ field_id }}" href="{{ url }}" title="{% trans 'Additional content settings' %}"><span class="svg-juxtaposed-font"><img src="{% static 'djangocms_content_expiry/svg/file.svg' %}" /></span></a>
+<a class="btn cms-moderation-action-btn js-moderation-action related-widget-wrapper-link cms-versioning-action-btn" id="change_content_expiry_id_{{ field_id }}" href="{{ url }}" title="{% trans 'Additional content settings' %}"><span class="svg-juxtaposed-font"><img src="{% static 'djangocms_content_expiry/svg/file.svg' %}" /></span></a>

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -20,9 +20,7 @@ from djangocms_content_expiry.test_utils.factories import (
     UserFactory,
 )
 from djangocms_content_expiry.test_utils.polls import factories
-from djangocms_content_expiry.test_utils.polls.cms_config import (
-    PollsCMSConfig,
-)
+from djangocms_content_expiry.test_utils.polls.cms_config import PollsCMSConfig
 
 
 class ContentExpiryMonkeyPatchTestCase(CMSTestCase):
@@ -252,4 +250,3 @@ class ContentExpiryMonkeyPatchTestCase(CMSTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, additional_settings_control, html=True)
-

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -9,7 +9,7 @@ from cms.test_utils.testcases import CMSTestCase
 from djangocms_moderation import constants
 from djangocms_versioning.constants import PUBLISHED
 
-from djangocms_content_expiry.constants import CONTENT_EXPIRY_EXPIRE_FIELD_LABEL
+from djangocms_content_expiry.constants import CONTENT_EXPIRY_COMPLIANCE_FIELD_LABEL
 from djangocms_content_expiry.models import ContentExpiry
 from djangocms_content_expiry.test_utils.factories import (
     ChildModerationRequestTreeNodeFactory,
@@ -65,8 +65,8 @@ class ContentExpiryMonkeyPatchTestCase(CMSTestCase):
         list_display = version_admin.get_list_display(request)
 
         # List display field should have been added by monkeypatch
-        self.assertIn('expire', list_display)
-        self.assertEqual(CONTENT_EXPIRY_EXPIRE_FIELD_LABEL, version_admin.expire.short_description)
+        self.assertIn('compliance_number', list_display)
+        self.assertEqual(CONTENT_EXPIRY_COMPLIANCE_FIELD_LABEL, version_admin.compliance_number.short_description)
 
     def test_extended_moderation_admin_update_existing_expiry_record(self):
         """


### PR DESCRIPTION
- Removed expiry date from version table and replaced with compliance number. 
- Added additional content settings icon to actions on the version table