### PR TITLE
fix: Fixed inconsistency in Content Expiry form field UI behaviour for the compliance number

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 unreleased
 ==========
+* fix: Fixed inconsistency field UI behaviour
 
 1.4.1 (2022-07-06)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 unreleased
 ==========
-* fix: Fixed inconsistency field UI behaviour
+* fix: Fixed inconsistency in Content Expiry form field UI behaviour for the compliance number
 
 1.4.1 (2022-07-06)
 ==================

--- a/djangocms_content_expiry/admin.py
+++ b/djangocms_content_expiry/admin.py
@@ -47,6 +47,7 @@ class ContentExpiryAdmin(admin.ModelAdmin):
                 'djangocms_content_expiry/css/actions.css',
                 'djangocms_content_expiry/css/date_filter.css',
                 'djangocms_content_expiry/css/multiselect_filter.css',
+                'djangocms_content_expiry/css/forms_style.css',
             )
         }
 

--- a/djangocms_content_expiry/static/djangocms_content_expiry/css/actions.css
+++ b/djangocms_content_expiry/static/djangocms_content_expiry/css/actions.css
@@ -39,16 +39,3 @@ span.svg-juxtaposed-font {
     vertical-align: 20%;
     margin-top: -2px !important;
 }
-
-/*
-Compliance number is not a mandatory field and is certain scenarios read-only
-so below is required to make the labels and value field look consistent with other fields
-*/
-.field-compliance_number label {
-    color: #000!important;
-    font-weight: 700!important;
-}
-.field-compliance_number div {
-    margin-left: 0px!important;
-    margin-top: 0px!important;
-}

--- a/djangocms_content_expiry/static/djangocms_content_expiry/css/actions.css
+++ b/djangocms_content_expiry/static/djangocms_content_expiry/css/actions.css
@@ -39,3 +39,16 @@ span.svg-juxtaposed-font {
     vertical-align: 20%;
     margin-top: -2px !important;
 }
+
+/*
+Compliance number is not a mandatory field and is certain scenarios read-only
+so below is required to make the labels and value field look consistent with other fields
+*/
+.field-compliance_number label {
+    color: #000!important;
+    font-weight: 700!important;
+}
+.field-compliance_number div {
+    margin-left: 0px!important;
+    margin-top: 0px!important;
+}

--- a/djangocms_content_expiry/static/djangocms_content_expiry/css/forms_style.css
+++ b/djangocms_content_expiry/static/djangocms_content_expiry/css/forms_style.css
@@ -1,0 +1,12 @@
+/*
+Compliance number is not a mandatory field and is certain scenarios read-only
+so below is required to make the labels and value field look consistent with other fields
+*/
+.field-compliance_number label {
+    color: #000!important;
+    font-weight: 700!important;
+}
+.field-compliance_number div {
+    margin-left: 0px!important;
+    margin-top: 0px!important;
+}


### PR DESCRIPTION
- Because compliance number is not a mandatory field, django renders the field label without bolding the text
- When the compliance number field is read-only, the value field is rendered as a div and not input. Additional CSS required to simulate look and feel of other fields to make it consistent 

![image](https://user-images.githubusercontent.com/18738275/177795910-9887aca8-ca53-4291-88ae-ba8802976821.png)

![image](https://user-images.githubusercontent.com/18738275/177796202-e31e29c2-ba78-42cc-99ef-dd1f9063b79e.png)
